### PR TITLE
translate(zh-HANT): refine freeway and highway lane naming

### DIFF
--- a/project/zh-HANT/Mod/Freeway_6_Lane.json
+++ b/project/zh-HANT/Mod/Freeway_6_Lane.json
@@ -1,0 +1,3 @@
+{
+  "Assets.NAME[Freeway 6 Lane]": "單向六線公路"
+}

--- a/project/zh-HANT/Mod/Highway_10_Lane.json
+++ b/project/zh-HANT/Mod/Highway_10_Lane.json
@@ -1,3 +1,3 @@
 {
-  "Assets.NAME[Highway 10 Lane]": "高速公路 10 車道"
+  "Assets.NAME[Highway 10 Lane]": "雙向十線公路"
 }

--- a/project/zh-HANT/Mod/Highway_12_Lane.json
+++ b/project/zh-HANT/Mod/Highway_12_Lane.json
@@ -1,3 +1,3 @@
 {
-  "Assets.NAME[Highway 12 Lane]": "高速公路 12 車道"
+  "Assets.NAME[Highway 12 Lane]": "雙向十二線公路"
 }

--- a/project/zh-HANT/Mod/Highway_6_Lane.json
+++ b/project/zh-HANT/Mod/Highway_6_Lane.json
@@ -1,3 +1,3 @@
 {
-  "Assets.NAME[Highway 6 Lane]": "高速公路 6 車道"
+  "Assets.NAME[Highway 6 Lane]": "雙向六線公路"
 }

--- a/project/zh-HANT/Mod/Highway_8_Lane.json
+++ b/project/zh-HANT/Mod/Highway_8_Lane.json
@@ -1,3 +1,3 @@
 {
-  "Assets.NAME[Highway 8 Lane]": "高速公路 8 車道"
+  "Assets.NAME[Highway 8 Lane]": "雙向八線公路"
 }

--- a/project/zh-HANT/Mod/MedicalHelicopterDepot01W.json
+++ b/project/zh-HANT/Mod/MedicalHelicopterDepot01W.json
@@ -1,0 +1,4 @@
+{
+  "Assets.NAME[MedicalHelicopterDepot01W]": "醫療直升機基地",
+  "Assets.DESCRIPTION[MedicalHelicopterDepot01W]": "專為醫療救援直升機設置的基地，配備五架完善裝備的直升機，隨時可進行快速醫療後送與緊急病患運送。"
+}


### PR DESCRIPTION
This PR improves Traditional Chinese (zh-HANT) localization for several road and service assets.

Changes include:
- Added translations for Freeway 6 Lane and MedicalHelicopterDepot01W
- Refined lane naming for Highway 6/8/10/12 Lane to improve consistency and clarity

# Localization / Language Confirmation

Please confirm that this PR only includes **supported language codes** and corresponding files.

## Supported language files

- [ ] `de-DE` (German)
- [ ] `en-US` (English, US)
- [ ] `es-ES` (Spanish, Spain)
- [ ] `fr-FR` (French)
- [ ] `it-IT` (Italian)
- [ ] `ja-JP` (Japanese)
- [ ] `ko-KR` (Korean)
- [ ] `pl-PL` (Polish)
- [ ] `pt-BR` (Portuguese, Brazil)
- [ ] `ru-RU` (Russian)
- [ ] `zh-HANS` (Chinese, Simplified)
- [X] `zh-HANT` (Chinese, Traditional)

> ⚠️ **Do not add or rename language codes outside this list.**  
> Unsupported or non-standard language codes will be rejected.

---

## Mod Conflict Prevention Check

To avoid localization conflicts, this repository **must not** include mods that are already listed as *self-deployed* or *externally maintained*.

Please confirm:

- [X] I have checked the **List of Mods Seeking Translators**
- [X] This PR does **NOT** include localization files for any mod listed there

Reference list:  
<https://github.com/CitiesSkylinesModding/PdxModsIntlCrawler/blob/main/List%20of%20Mods%20Seeking%20Translators.md>

---

## Validation Checklist

- [X] JSON files are valid and properly formatted
- [X] No unrelated files are included
- [X] Changes are limited to localization content only
- [X] No duplicate or conflicting mod entries are introduced
